### PR TITLE
Bring UI header closer to parity with glogtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ rtimelog is a simple console/text based time tracker. It is inspired by
 [gtimelog](https://gtimelog.org/) and uses the same data format and data file
 (`~/.gtimelog/timelog.txt`), so you can use gtimelog and rtimelog in parallel.
 
-Hoever, it has far fewer features. This was a toy project for learning Rust,
+However, it has far fewer features. This was a toy project for learning Rust,
 and I don't use many gtimelog features myself. If you need one, please feel
 free to send a PR, or file an issue.
 
@@ -78,6 +78,6 @@ you can run it with
 
 Run the unit tests with
 
-    cargo build
+    cargo test
 
 ![tests](https://github.com/martinpitt/rtimelog/actions/workflows/tests.yml/badge.svg)

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn show(timelog: &Timelog, mode: &TimeMode, rl_editor: &mut Editor<()>) {
             timelog.get_today()
         }
         TimeMode::Week => {
-            println!("Work done this week:");
+            println!("Work done this week {}:", timelog.get_this_week_as_string());
             timelog.get_this_week()
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn show(timelog: &Timelog, mode: &TimeMode, rl_editor: &mut Editor<()>) {
     clear_screen();
     let entries = match mode {
         TimeMode::Day => {
-            println!("Work done today:");
+            println!("Work done today {}:", timelog.get_today_as_string());
             timelog.get_today()
         }
         TimeMode::Week => {

--- a/src/store.rs
+++ b/src/store.rs
@@ -232,6 +232,14 @@ impl Timelog {
         self.get_week(&Local::now().date_naive())
     }
 
+    pub fn get_this_week_as_string(&self) -> String {
+        let now_local = Local::now();
+        let week_begin = now_local.day() - now_local.weekday().num_days_from_monday();
+        let week_end = week_begin + 6;
+        let this_week = format!("{} {}-{}", now_local.format("%B"), week_begin, week_end);
+        format!("{} ({})", now_local.format("%Y, week %U"), this_week)
+    }
+
     pub fn get_history(entries: &[Entry]) -> Vec<&String> {
         let mut seen = HashSet::new();
         entries

--- a/src/store.rs
+++ b/src/store.rs
@@ -211,6 +211,10 @@ impl Timelog {
         self.get_day(&Local::now().date_naive())
     }
 
+    pub fn get_today_as_string(&self) -> String {
+        Local::now().format("%A, %F (week %U)").to_string()
+    }
+
     pub fn get_week(&self, day: &NaiveDate) -> &[Entry] {
         let week = day.iso_week().week();
         let begin = NaiveDate::from_isoywd_opt(day.year(), week, Weekday::Mon)


### PR DESCRIPTION
rlogtime is a good tui that can be run in parallel with the glogtime gui, but the UI of rlogtime is slightly divergent. This is the start of an attempt to bring them closer together, so that if you have both up at the same time, you see basically the same information.