### PR TITLE
Fix week calculation and slack items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ name = "rtimelog"
 chrono = "0.4.23"
 dirs = "4"
 rustyline = "10"
+
+[dev-dependencies]
+pretty_assertions = "1.3.0"

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -69,7 +69,7 @@ impl Activities {
                     }
 
                     let duration = entry.stop.signed_duration_since(prev_stop_time);
-                    if entry.task.starts_with("**") {
+                    if entry.task.contains("**") {
                         total_slack = total_slack + duration;
                     } else {
                         total_work = total_work + duration;

--- a/src/activity.rs
+++ b/src/activity.rs
@@ -130,6 +130,7 @@ mod tests {
     use super::*;
     use crate::store::Timelog;
     use chrono::NaiveDate;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_activity_display() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -273,6 +273,7 @@ impl Timelog {
 mod tests {
     use super::*;
     use chrono::Duration;
+    use pretty_assertions::assert_eq;
 
     const TWO_DAYS: &'static str = "
 2022-06-09 06:02: arrived

--- a/src/store.rs
+++ b/src/store.rs
@@ -212,7 +212,7 @@ impl Timelog {
     }
 
     pub fn get_today_as_string(&self) -> String {
-        Local::now().format("%A, %F (week %U)").to_string()
+        Local::now().format("%A, %F (week %W)").to_string()
     }
 
     pub fn get_week(&self, day: &NaiveDate) -> &[Entry] {
@@ -237,7 +237,7 @@ impl Timelog {
         let week_begin = now_local.day() - now_local.weekday().num_days_from_monday();
         let week_end = week_begin + 6;
         let this_week = format!("{} {}-{}", now_local.format("%B"), week_begin, week_end);
-        format!("{} ({})", now_local.format("%Y, week %U"), this_week)
+        format!("{} ({})", now_local.format("%Y, week %W"), this_week)
     }
 
     pub fn get_history(entries: &[Entry]) -> Vec<&String> {


### PR DESCRIPTION
Continuation of PR #4, adds the "`Time left at work`" and "`At office today`" metrics.

Also fixes a couple of bugs both latent and introduced with the last PR (see each commit for the specifics).

This breaks two unit tests, which I haven't figured a good way to resolve yet. Run `cargo test` to see what I mean. I also introduced a dev-dependency to pretty-assertions to more easily see why a unit test is failing. Any advice on how to resolve this would be appreciated.